### PR TITLE
Write the inputIndex to sql dump

### DIFF
--- a/cb/sql.cpp
+++ b/cb/sql.cpp
@@ -315,7 +315,7 @@ struct SQLDump:public Callback
             inputID++,
             src->second,
             txID,
-            (uint32_t)outputIndex
+            (uint32_t)inputIndex
         );
     }
 


### PR DESCRIPTION
We store the output index in transaction input. This is wrong, we already store that on output table. This commit fix this.