### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/util.h
+++ b/util.h
@@ -76,6 +76,9 @@
         static uint8_t *alloc() {
             if(unlikely(poolEnd<=pool)) {
                 pool = (uint8_t*)malloc(kPageByteSize);
+				if (!pool) {
+					sysErrFatal("failed to allocate page");
+				}
                 poolEnd = kPageByteSize + pool;
             }
             uint8_t *result = pool;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V769](https://www.viva64.com/en/w/v769/) The 'pool' pointer in the 'kPageByteSize + pool' expression could be nullptr. In such case, resulting value will be senseless and it should not be used. Check lines: 79, 78. util.h 79